### PR TITLE
feat: 회원탈퇴 페이지 추가

### DIFF
--- a/app/(auth)/account-delete/components/AccountDeleteClient.tsx
+++ b/app/(auth)/account-delete/components/AccountDeleteClient.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { deleteUser } from "../../signup/api";
+import { openAlert } from "@/utils/modal/OpenAlert";
+import { openConfirm } from "@/utils/modal/OpenConfirm";
+import SessionGuard from "@/components/guards/SessionGuard";
+import { ROUTES } from "@/constants/routes";
+
+export default function AccountDeleteClient() {
+  const [deleteReason, setDeleteReason] = useState("");
+  const router = useRouter();
+
+  const deleteUserMutation = useMutation({
+    mutationFn: deleteUser,
+    onSuccess: () => {
+      window.location.href = ROUTES.ROOT;
+    },
+    onError: (error) => {
+      console.error("계정 삭제 실패:", error);
+      openAlert(
+        "계정 삭제 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
+      );
+    },
+  });
+
+  const handleDelete = () => {
+    if (!deleteReason.trim()) {
+      openAlert("삭제 이유를 입력해주세요.");
+      return;
+    }
+
+    openConfirm(
+      "정말로 계정을 삭제하시겠습니까?",
+      () => {
+        deleteUserMutation.mutate();
+      },
+      undefined,
+      "삭제하기",
+      "취소"
+    );
+  };
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  return (
+    <>
+      <SessionGuard />
+      <div className="flex min-h-screen items-center justify-center p-4">
+        {/* 데스크톱: 피그마 정확한 크기, 모바일: 패딩과 함께 조정 */}
+        <div className="relative h-auto w-full max-w-[426px] md:h-[372px] md:w-[426px]">
+          {/* 제목 */}
+          <h1 className="mb-6 text-center text-xl font-semibold leading-6 text-black md:absolute md:left-[113px] md:top-0 md:mb-0 md:text-2xl">
+            핏더맨 계정 삭제하기
+          </h1>
+
+          {/* 설명 텍스트 */}
+          <p className="mb-8 text-center text-sm font-medium leading-[21px] text-[#374254] md:absolute md:left-0 md:top-[48px] md:mb-0 md:w-[426px]">
+            계정을 삭제하시면 그동안 핏더맨에 올려주신 글과 정보가 모두
+            삭제됩니다.
+            <br />
+            그루밍 지수 검사 내역은 계정 삭제 후 30일 내에 재가입 시 복구가
+            가능합니다.
+          </p>
+
+          {/* 삭제 이유 라벨 */}
+          <label className="mb-2 block text-sm font-medium leading-[14px] text-[#374254] md:absolute md:left-[17px] md:top-[162px] md:mb-0">
+            어떤 이유로 삭제하시는지 알려주시겠어요?
+          </label>
+
+          {/* 입력 필드 */}
+          <div className="mb-6 h-[38px] w-full rounded-[10px] border border-[#eaeaec] bg-[#f1f1f1] bg-opacity-50 md:absolute md:left-[17px] md:top-[186px] md:mb-0 md:w-[392px]">
+            <input
+              type="text"
+              value={deleteReason}
+              onChange={(e) => setDeleteReason(e.target.value)}
+              placeholder="삭제 이유를 알려주세요"
+              className="h-full w-full rounded-[10px] bg-transparent px-3 py-2 text-sm placeholder-[#c5c5c5] focus:outline-none"
+              disabled={deleteUserMutation.isPending}
+            />
+          </div>
+
+          {/* 삭제 버튼 */}
+          <button
+            onClick={handleDelete}
+            disabled={!deleteReason.trim() || deleteUserMutation.isPending}
+            className="mb-4 h-[38px] w-full rounded-xl bg-[#ff5b45] text-sm font-medium text-white transition-colors hover:bg-[#ff5b45]/90 disabled:cursor-not-allowed disabled:bg-gray-300 md:absolute md:left-[17px] md:top-[296px] md:mb-0 md:w-[392px]"
+          >
+            {deleteUserMutation.isPending ? "삭제 중..." : "삭제하기"}
+          </button>
+
+          {/* 뒤로 가기 버튼 */}
+          <button
+            onClick={handleGoBack}
+            disabled={deleteUserMutation.isPending}
+            className="w-full text-center text-sm font-medium text-[#374254] transition-colors hover:text-[#374254]/80 disabled:text-gray-400 md:absolute md:left-[187px] md:top-[358px] md:w-auto"
+          >
+            뒤로 가기
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(auth)/account-delete/page.tsx
+++ b/app/(auth)/account-delete/page.tsx
@@ -1,0 +1,5 @@
+import AccountDeleteClient from "./components/AccountDeleteClient";
+
+export default function AccountDeletePage() {
+  return <AccountDeleteClient />;
+}

--- a/app/(auth)/signup/api/index.ts
+++ b/app/(auth)/signup/api/index.ts
@@ -121,7 +121,7 @@ export const deleteUser = async (): Promise<ApiResponse> => {
     const response = await authApi.delete<ApiResponse>(`${BASE_PATH}`);
     return response.data;
   } catch (error) {
-    console.error("회원가입 실패:", error);
+    console.error("회원탈퇴 실패:", error);
     throw error;
   }
 };

--- a/app/(main)/components/sidebar/(left)/LeftSidebar.tsx
+++ b/app/(main)/components/sidebar/(left)/LeftSidebar.tsx
@@ -6,11 +6,9 @@ import SideCategoryItem from "./SideCategoryItem";
 import ProfileCard from "./ProfileCard";
 import { usePathname } from "next/navigation";
 import { ROUTES } from "@/constants/routes";
-import { deleteUser } from "@/app/(auth)/signup/api";
 
 export default function LeftSidebar() {
   const [activeMenu, setActiveMenu] = useState("유형별 추천");
-  const [isDeleting, setIsDeleting] = useState(false);
   const pathname = usePathname();
 
   const allMenuItems = [
@@ -29,41 +27,11 @@ export default function LeftSidebar() {
     ? userPickMenuItems
     : allMenuItems;
 
-  const handleDeleteUser = async () => {
-    if (!confirm("정말로 회원탈퇴를 진행하시겠습니까?")) {
-      return;
-    }
-
-    setIsDeleting(true);
-    try {
-      await deleteUser();
-      alert("회원탈퇴가 완료되었습니다.");
-      // 로그아웃 처리나 홈페이지로 리다이렉트
-      window.location.href = "/";
-    } catch (error) {
-      console.error("회원탈퇴 실패:", error);
-      alert("회원탈퇴에 실패했습니다.");
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
   return (
     <div className="ml-[18px] flex h-auto min-h-[558px] w-[324px] flex-col gap-[110px] p-4">
       <div className="min-h-[200px] w-[288px]">
         <SectionTitle title="마이 프로필" />
         <ProfileCard />
-
-        {/* 테스트용 회원탈퇴 버튼 */}
-        <div className="mt-4">
-          <button
-            onClick={handleDeleteUser}
-            disabled={isDeleting}
-            className="w-full rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:bg-red-300"
-          >
-            {isDeleting ? "처리중..." : "회원탈퇴 (테스트)"}
-          </button>
-        </div>
       </div>
 
       <nav>


### PR DESCRIPTION
회원탈퇴 페이지 추가 하였습니다.

/accout-delete 

이동 경로는 마이페이지에서 이동했던거 같은데 이부분은 따로 또 확인을 해볼게요

탈퇴페이지에서 사유도 적게끔 되어있는데 현재 API상으론 따로 탈퇴 이유를 넣는 정보가 없어 따로 보내진 않고 있습니다.

회원탈퇴를 하고 페이지 이동을 어디로 해야할지 고민 해봐야될거 같네요~

문제는 현재구조에선 회원탈퇴 시 쿠키세션도 사라져서  세션만료 팝업도 같이 노출이 되긴 하는데

이 팝업에서 확인누를 시 로그인 페이지로 이동하고 있어서  어떻게 처리할 지는 고민좀 해보겠습니다.  